### PR TITLE
Windows support workaround

### DIFF
--- a/runner/start_unix.go
+++ b/runner/start_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package runner
 
 import (

--- a/runner/start_windows.go
+++ b/runner/start_windows.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+var (
+	startChannel chan string
+	stopChannel  chan bool
+	mainLog      logFunc
+	watcherLog   logFunc
+	runnerLog    logFunc
+	buildLog     logFunc
+	appLog       logFunc
+)
+
+func flushEvents() {
+	for {
+		select {
+		case eventName := <-startChannel:
+			mainLog("receiving event %s", eventName)
+		default:
+			return
+		}
+	}
+}
+
+func start() {
+	loopIndex := 0
+	buildDelay := buildDelay()
+
+	started := false
+
+	go func() {
+		for {
+			loopIndex++
+			mainLog("Waiting (loop %d)...", loopIndex)
+			eventName := <-startChannel
+
+			mainLog("receiving first event %s", eventName)
+			mainLog("sleeping for %d milliseconds", buildDelay)
+			time.Sleep(buildDelay * time.Millisecond)
+			mainLog("flushing events")
+
+			flushEvents()
+
+			mainLog("Started! (%d Goroutines)", runtime.NumGoroutine())
+			err := removeBuildErrorsLog()
+			if err != nil {
+				mainLog(err.Error())
+			}
+
+			errorMessage, ok := build()
+			if !ok {
+				mainLog("Build Failed: \n %s", errorMessage)
+				if !started {
+					os.Exit(1)
+				}
+				createBuildErrorsLog(errorMessage)
+			} else {
+				if started {
+					stopChannel <- true
+				}
+				run()
+			}
+
+			started = true
+			mainLog(strings.Repeat("-", 20))
+		}
+	}()
+}
+
+func init() {
+	startChannel = make(chan string, 1000)
+	stopChannel = make(chan bool)
+}
+
+func initLogFuncs() {
+	mainLog = newLogFunc("main")
+	watcherLog = newLogFunc("watcher")
+	runnerLog = newLogFunc("runner")
+	buildLog = newLogFunc("build")
+	appLog = newLogFunc("app")
+}
+
+func setEnvVars() {
+	os.Setenv("DEV_RUNNER", "1")
+	wd, err := os.Getwd()
+	if err == nil {
+		os.Setenv("RUNNER_WD", wd)
+	}
+
+	for k, v := range settings {
+		key := strings.ToUpper(fmt.Sprintf("%s%s", envSettingsPrefix, k))
+		os.Setenv(key, v)
+	}
+}
+
+// Watches for file changes in the root directory.
+// After each file system event it builds and (re)starts the application.
+func Start() {
+	initSettings()
+	initLogFuncs()
+	initFolders()
+	setEnvVars()
+	watch()
+	start()
+	startChannel <- "/"
+
+	<-make(chan int)
+}


### PR DESCRIPTION
Ability to build fresh on windows. Note that `build_name` parameter in `runner.conf` file should contain `.exe`-suffix or `exec.Command` won't be able to run it. Not sure if this must be appended by fresh itself or set manually by a developer.
