### PR TITLE
Remove tmp path issues

### DIFF
--- a/runner/utils.go
+++ b/runner/utils.go
@@ -27,7 +27,7 @@ func isWatchedFile(path string) bool {
 	absolutePath, _ := filepath.Abs(path)
 	absoluteTmpPath, _ := filepath.Abs(tmpPath())
 
-	if strings.HasPrefix(absolutePath, absoluteTmpPath) {
+	if strings.HasPrefix(absolutePath, absoluteTmpPath+"/") {
 		return false
 	}
 


### PR DESCRIPTION
I had a small issue. According to https://golang.org/doc/articles/wiki/ I created my application in Go with a "tmpl" folder for my HTML template files. 

Unfortunately fresh skipped my "tmpl" folder because it has the same prefix as the "tmp" folder. 