### PR TITLE
Add ability to ignore a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Here is a sample config file with the default settings:
 
     root:              .
     tmp_path:          ./tmp
+    ignore_path:          
     build_name:        runner-build
     build_log:         runner-build-errors.log
     valid_ext:         .go, .tpl, .tmpl, .html

--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -1,5 +1,6 @@
 root:              .
 tmp_path:          ./tmp
+ignore_path        ./frontend
 build_name:        runner-build
 build_log:         runner-build-errors.log
 valid_ext:         .go, .tpl, .tmpl, .html

--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -1,6 +1,6 @@
 root:              .
 tmp_path:          ./tmp
-ignore_path        ./frontend
+ignore_path:
 build_name:        runner-build
 build_log:         runner-build-errors.log
 valid_ext:         .go, .tpl, .tmpl, .html

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -19,6 +19,7 @@ var settings = map[string]string{
 	"config_path":       "./runner.conf",
 	"root":              ".",
 	"tmp_path":          "./tmp",
+	"ignore_path":       "",
 	"build_name":        "runner-build",
 	"build_log":         "runner-build-errors.log",
 	"valid_ext":         ".go, .tpl, .tmpl, .html",
@@ -110,6 +111,10 @@ func root() string {
 
 func tmpPath() string {
 	return settings["tmp_path"]
+}
+
+func ignorePath() string {
+	return settings["ignore_path"]
 }
 
 func buildName() string {

--- a/runner/utils.go
+++ b/runner/utils.go
@@ -23,6 +23,13 @@ func isTmpDir(path string) bool {
 	return absolutePath == absoluteTmpPath
 }
 
+func isIgnoreDir(path string) bool {
+	absolutePath, _ := filepath.Abs(path)
+	absoluteIgnorePath, _ := filepath.Abs(ignorePath())
+
+	return absolutePath == absoluteIgnorePath
+}
+
 func isWatchedFile(path string) bool {
 	absolutePath, _ := filepath.Abs(path)
 	absoluteTmpPath, _ := filepath.Abs(tmpPath())

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -38,8 +38,8 @@ func watchFolder(path string) {
 func watch() {
 	root := root()
 	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() && !isTmpDir(path) && !isIgnoreDir(path) {
-			if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
+		if info.IsDir() && !isTmpDir(path) {
+			if (len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".")) || (isIgnoreDir(path)) {
 				return filepath.SkipDir
 			}
 

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -38,7 +38,7 @@ func watchFolder(path string) {
 func watch() {
 	root := root()
 	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() && !isTmpDir(path) {
+		if info.IsDir() && !isTmpDir(path) && !isIgnoreDir(path) {
 			if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
I'm unable to use Fresh with one of my web applications because it contains a `frontend` directory with several thousand javascript files (`node_modules`). When attempting to run Fresh on the application directory, it attempts to watch each of these files and subsequently crashes ("too many open files").

This PR adds a configuration setting to ignore a folder in the directory which Fresh is run in.