### PR TITLE
cp os.Args to runner

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,22 +13,25 @@ Traffic (https://github.com/pilu/traffic) already has a middleware that shows th
 package main
 
 import (
-	"flag"
 	"fmt"
 	"github.com/pilu/fresh/runner"
 	"os"
 )
 
 func main() {
-	configPath := flag.String("c", "", "config file path")
-	flag.Parse()
 
-	if *configPath != "" {
-		if _, err := os.Stat(*configPath); err != nil {
-			fmt.Printf("Can't find config file `%s`\n", *configPath)
+	configPath := ""
+	args := os.Args
+	if len(args) > 2 && args[1] == "-c" {
+		configPath = args[2]
+	}
+
+	if configPath != "" {
+		if _, err := os.Stat(configPath); err != nil {
+			fmt.Printf("Can't find config file `%s`\n", configPath)
 			os.Exit(1)
 		} else {
-			os.Setenv("RUNNER_CONFIG_PATH", *configPath)
+			os.Setenv("RUNNER_CONFIG_PATH", configPath)
 		}
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"io"
+	"os"
 	"os/exec"
 )
 
@@ -9,6 +10,10 @@ func run() bool {
 	runnerLog("Running...")
 
 	cmd := exec.Command(buildPath())
+
+	if len(os.Args) > 2 && os.Args[1] == "-c" {
+		cmd.Args = append([]string{buildPath()}, os.Args[3:]...)
+	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {


### PR DESCRIPTION
support copy os.Args to runner, eg.
`fresh -c fresh.conf -f conf.json` will set `<build_name> -f conf.json` to build_name os.Args