### PR TITLE
README update: clarified default runner.conf usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ If `go build` returns an error, it will log it in the tmp folder.
 [Traffic](https://github.com/pilu/traffic) already has a middleware that shows the content of that file if it is present. This middleware is automatically added if you run a Traffic web app in dev mode with Fresh.
 Check the `_examples` folder if you want to use it with Martini or Gocraft Web.
 
-You can use the `-c` options if you want to specify a config file:
+`fresh` uses `./runner.conf` for configuration by default, but you may specify an alternative config filepath using `-c`:
 
-    fresh -c runner.conf
+    fresh -c other_runner.conf
 
 Here is a sample config file with the default settings:
 


### PR DESCRIPTION
Documentation did not state that fresh uses ./runner.conf as default configuration file. Updated README to be explicit about this.