### PR TITLE
Add condition for not escape formatted log

### DIFF
--- a/runner/logger.go
+++ b/runner/logger.go
@@ -12,7 +12,7 @@ type logFunc func(string, ...interface{})
 
 var logger = logPkg.New(colorable.NewColorableStderr(), "", 0)
 
-func newLogFunc(prefix string) func(string, ...interface{}) {
+func newLogFunc(prefix string, withEscape bool) func(string, ...interface{}) {
 	color, clear := "", ""
 	if settings["colors"] == "1" {
 		color = fmt.Sprintf("\033[%sm", logColor(prefix))
@@ -24,7 +24,11 @@ func newLogFunc(prefix string) func(string, ...interface{}) {
 		now := time.Now()
 		timeString := fmt.Sprintf("%d:%d:%02d", now.Hour(), now.Minute(), now.Second())
 		format = fmt.Sprintf("%s%s %s |%s %s", color, timeString, prefix, clear, format)
-		logger.Printf(format, v...)
+		if withEscape {
+			logger.Printf(format, v...)
+		} else {
+			logger.Print(format)
+		}
 	}
 }
 

--- a/runner/start.go
+++ b/runner/start.go
@@ -80,11 +80,11 @@ func init() {
 }
 
 func initLogFuncs() {
-	mainLog = newLogFunc("main")
-	watcherLog = newLogFunc("watcher")
-	runnerLog = newLogFunc("runner")
-	buildLog = newLogFunc("build")
-	appLog = newLogFunc("app")
+	mainLog = newLogFunc("main", true)
+	watcherLog = newLogFunc("watcher", true)
+	runnerLog = newLogFunc("runner", true)
+	buildLog = newLogFunc("build", true)
+	appLog = newLogFunc("app", false)
 }
 
 func setEnvVars() {


### PR DESCRIPTION
Hi,
    When the log contained some escape character (for example %2c), the Fresh output a missing information like %!C(MISSING). This is just because the method Printf regards %2c as a placeholder, so I add this.