### PR TITLE
Allow watching other dirs

### DIFF
--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -1,4 +1,5 @@
 root:              .
+watch_dir:         .
 tmp_path:          ./tmp
 build_name:        runner-build
 build_log:         runner-build-errors.log

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -111,6 +111,14 @@ func root() string {
 	return settings["root"]
 }
 
+func rootorwatchdir() string {
+	if settings["watch_dir"] != "" {
+		return settings["watch_dir"]
+	} else {
+		return root()
+	}
+}
+
 func tmpPath() string {
 	return settings["tmp_path"]
 }

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -42,7 +42,7 @@ func watchFolder(path string) {
 }
 
 func watch() {
-	root := root()
+	root := rootorwatchdir()
 	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() && !isTmpDir(path) {
 			if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {


### PR DESCRIPTION
When you have the cli in another directory you setup root: ./cli/ to get it running from there, adding watching_dir so it can watches change on another dir than just ./cli in this case (and could be useful in other use cases)