### PR TITLE
Extra watch directories for multiple apps repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+.idea

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Check the `_examples` folder if you want to use it with Martini or Gocraft Web.
 Here is a sample config file with the default settings:
 
     root:              .
+    include:           
     tmp_path:          ./tmp
     build_name:        runner-build
     build_log:         runner-build-errors.log

--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -1,4 +1,5 @@
 root:              .
+include:           
 tmp_path:          ./tmp
 build_name:        runner-build
 build_log:         runner-build-errors.log

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -20,6 +20,7 @@ const (
 var settings = map[string]string{
 	"config_path":       "./runner.conf",
 	"root":              ".",
+	"include":           "",
 	"tmp_path":          "./tmp",
 	"build_name":        "runner-build",
 	"build_log":         "runner-build-errors.log",
@@ -110,6 +111,10 @@ func getenv(key, defaultValue string) string {
 
 func root() string {
 	return settings["root"]
+}
+
+func include() string {
+	return settings["include"]
 }
 
 func tmpPath() string {

--- a/runner/utils.go
+++ b/runner/utils.go
@@ -87,3 +87,15 @@ func removeBuildErrorsLog() error {
 
 	return err
 }
+
+func getDirsToWatch() []string {
+	dirs := []string{root()}
+
+	include := strings.Trim(include(), " :")
+	if len(include) > 0 {
+		includeDirs := strings.Split(include, ":")
+		dirs = append(dirs, includeDirs...)
+	}
+
+	return dirs
+}

--- a/runner/utils_test.go
+++ b/runner/utils_test.go
@@ -66,3 +66,22 @@ func TestIsIgnoredFolder(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDirsToWatch(t *testing.T) {
+	settings["root"] = ".";
+	settings["include"] = "/absolute/path/to/packages:../relative/path/to/watch";
+
+
+	expected := []string{
+		".",
+		"/absolute/path/to/packages",
+		"../relative/path/to/watch",
+	}
+	actual := getDirsToWatch()
+
+	for i, e := range expected {
+		if e != actual[i] {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	}
+}

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/howeyc/fsnotify"
+	"log"
 )
 
 func watchFolder(path string) {
@@ -41,6 +42,10 @@ func watch() {
 
 	for _, dir := range dirs {
 		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Fatal(err)
+			}
+
 			if info.IsDir() && !isTmpDir(path) {
 				if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
 					return filepath.SkipDir

--- a/runner/watcher.go
+++ b/runner/watcher.go
@@ -37,21 +37,24 @@ func watchFolder(path string) {
 }
 
 func watch() {
-	root := root()
-	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() && !isTmpDir(path) {
-			if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
-				return filepath.SkipDir
+	dirs := getDirsToWatch()
+
+	for _, dir := range dirs {
+		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() && !isTmpDir(path) {
+				if len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") {
+					return filepath.SkipDir
+				}
+	
+				if isIgnoredFolder(path) {
+					watcherLog("Ignoring %s", path)
+					return filepath.SkipDir
+				}
+	
+				watchFolder(path)
 			}
-
-			if isIgnoredFolder(path) {
-				watcherLog("Ignoring %s", path)
-				return filepath.SkipDir
-			}
-
-			watchFolder(path)
-		}
-
-		return err
-	})
+	
+			return err
+		})
+	}
 }


### PR DESCRIPTION
I've added support for multiple apps repositories.
Multiple independent apps can live in the same repository and share some packages.

A structure example:
/apps/app1
/apps/app2
/packages/pkg1
/packages/pkg2

The apps can be developed/run/built independently, while they are both going to use some packages.
While developing "app1", I would like to watch for changes in its root directory (/apps/app1) and also in "/packages", but not in "/apps/app2".

Multiple extra directories can be defined with the ":" path separator. Both absolute and relative paths are accepted.

A config example that both apps can share:
root:              .
include:       /home/user/go/src/name/space/packages/pkg1:../pkg2

I've also handled the case where a watch was requested for a nonexistent directory.